### PR TITLE
feat(sat_feedback): add attachment

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,6 +24,8 @@ gem "uglifier", "~> 4.1"
 gem "faker", "~> 2.14"
 gem "rspec"
 
+gem "image_processing", ">= 1.2"
+
 group :development, :test do
   gem "byebug", "~> 11.0", platform: :mri
   gem "rubocop-faker"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -887,6 +887,7 @@ DEPENDENCIES
   figaro (~> 1.2)
   fog-aws
   health_check
+  image_processing (>= 1.2)
   letter_opener_web
   listen (~> 3.1)
   puma (>= 5.0.0)

--- a/app/cells/indices/sat_feedback/show.erb
+++ b/app/cells/indices/sat_feedback/show.erb
@@ -2,7 +2,11 @@
   <div class="card">
     <div class="row card-section">
       <div class="column small-3">
-        <%= image_pack_tag "media/images/default-avatar.svg", alt: "member-avatar" %>
+        <% if model.avatar.attached? %>
+          <%= image_tag model.avatar_thumb_path, alt: "Avatar for #{title}" %>
+        <% else %>
+          <%= image_pack_tag "media/images/default-avatar.svg", alt: "member-avatar" %>
+        <% end %>
       </div>
 
       <div class="column small-9">

--- a/app/commands/decidim/admin/create_indices_sat_feedback.rb
+++ b/app/commands/decidim/admin/create_indices_sat_feedback.rb
@@ -12,10 +12,12 @@ module Decidim
         return broadcast(:invalid) unless form.valid?
 
         begin
-          create_sat_set!
+          create_sat_feedback!
         rescue StandardError => e
           return broadcast(:invalid, e.message)
         end
+
+        sat_feedback.avatar.attach(form.avatar)
 
         broadcast(:ok, sat_feedback)
       end
@@ -24,7 +26,7 @@ module Decidim
 
       attr_reader :form, :sat_set, :sat_feedback
 
-      def create_sat_set!
+      def create_sat_feedback!
         @sat_feedback = Indices::SatFeedback.create!(
           sat_set: sat_set,
           title: form.title,

--- a/app/commands/decidim/admin/update_indices_sat_feedback.rb
+++ b/app/commands/decidim/admin/update_indices_sat_feedback.rb
@@ -36,7 +36,9 @@ module Decidim
         }
 
         sat_feedback.update!(attributes)
-        sat_feedback.avatar.attach(form.avatar)
+
+        sat_feedback.avatar.attach(form.avatar) if form.avatar
+        sat_feedback.avatar.purge if form.remove_avatar
       end
     end
   end

--- a/app/commands/decidim/admin/update_indices_sat_feedback.rb
+++ b/app/commands/decidim/admin/update_indices_sat_feedback.rb
@@ -26,13 +26,17 @@ module Decidim
       attr_reader :form, :sat_set, :sat_feedback
 
       def update_sat_feedback!
-        @sat_feedback.sat_set = sat_set
-        @sat_feedback.title = form.title
-        @sat_feedback.subtitle = form.subtitle
-        @sat_feedback.description = form.description
-        @sat_feedback.effort = form.effort
-        @sat_feedback.hashtags = form.hashtags
-        @sat_feedback.save!
+        attributes = {
+          sat_set: sat_set,
+          title: form.title,
+          subtitle: form.subtitle,
+          description: form.description,
+          effort: form.effort,
+          hashtags: form.hashtags
+        }
+
+        sat_feedback.update!(attributes)
+        sat_feedback.avatar.attach(form.avatar)
       end
     end
   end

--- a/app/forms/decidim/admin/sat_feedback_form.rb
+++ b/app/forms/decidim/admin/sat_feedback_form.rb
@@ -14,6 +14,7 @@ module Decidim
       attribute :hashtags, Array
       attribute :effort, Integer
       attribute :avatar
+      attribute :remove_avatar, Boolean
 
       validates :title, translatable_presence: true
       validates :description, translatable_presence: true

--- a/app/forms/decidim/admin/sat_feedback_form.rb
+++ b/app/forms/decidim/admin/sat_feedback_form.rb
@@ -13,6 +13,7 @@ module Decidim
       translatable_attribute :description, String
       attribute :hashtags, Array
       attribute :effort, Integer
+      attribute :avatar
 
       validates :title, translatable_presence: true
       validates :description, translatable_presence: true

--- a/app/models/indices/sat_feedback.rb
+++ b/app/models/indices/sat_feedback.rb
@@ -4,6 +4,7 @@ module Indices
   # The data store for the self assessment tool set
   class SatFeedback < ApplicationRecord
     self.table_name = "indices_sat_feedbacks"
+    has_one_attached :avatar
 
     belongs_to :sat_set,
                class_name: "Indices::SatSet"
@@ -23,6 +24,13 @@ module Indices
         score = hashtags.filter_map { |tag| tag["tag"] == name ? tag["weight"].to_i : false }.sum
         [name, score * freq] if score
       end.to_h
+    end
+
+    def avatar_thumb_path
+      Rails.application.routes.url_helpers.rails_representation_url(
+        avatar.variant(resize_to_fill: [300, 300]),
+        only_path: true
+      )
     end
   end
 end

--- a/app/views/decidim/admin/indices_feedbacks/_form.html.erb
+++ b/app/views/decidim/admin/indices_feedbacks/_form.html.erb
@@ -14,6 +14,10 @@
   <%= form.number_field :effort %>
 </div>
 
+<div class="field">
+  <%= form.file_field :avatar %>
+</div>
+
 <table class="table-list">
   <thead>
     <tr>

--- a/app/views/decidim/admin/indices_feedbacks/_form.html.erb
+++ b/app/views/decidim/admin/indices_feedbacks/_form.html.erb
@@ -15,7 +15,17 @@
 </div>
 
 <div class="field">
-  <%= form.file_field :avatar %>
+  <%= form.file_field(:avatar, accept: 'image/png,image/gif,image/jpeg') %>
+
+  <% if sat_feedback.avatar.attached? %>
+    <div class="card" style="width: 300px;">
+      <%= image_tag sat_feedback.avatar_thumb_path, alt: "Avatar for #{sat_feedback.title}", title: "Current avatar" %>
+
+      <div class="card-section">
+        <%= form.check_box :remove_avatar, label: "Remove avatar" %>
+      </div>
+    </div>
+  <% end %>
 </div>
 
 <table class="table-list">


### PR DESCRIPTION
## Description

This PR adds the ability to an admin to attach (add/update/remove) an image to a `sat_feedback` record, this image is shown in the public feedback page.

## Screenshots

- ![sat_feedback-avatar](https://user-images.githubusercontent.com/210216/164201298-f9c24e08-68f0-4c89-b20b-4b510bfa57dc.png)
- ![sat_feedback-avatar_remove](https://user-images.githubusercontent.com/210216/164201307-7eb73730-c79c-4ebc-a2c1-21462e7dedb3.png)
- ![sat_feedback_add_avatar](https://user-images.githubusercontent.com/210216/164201315-9d1a2efe-993a-4267-b694-39ad79bd33d0.png)

## Related
- #49