### PR TITLE
Next and previous survey buttons fix

### DIFF
--- a/decidim-module-survey_sections_group/app/models/decidim/survey_sections_group/survey_group.rb
+++ b/decidim-module-survey_sections_group/app/models/decidim/survey_sections_group/survey_group.rb
@@ -15,7 +15,7 @@ module Decidim
             .where("decidim_components.weight < ?", survey.weight)
             .sort_by { |s| s.survey.weight }
             .reverse
-            &.find { |s| !s.survey.answered_by?(user.id) }
+            .find { |s| !s.survey.answered_by?(user.id) }
       end
 
       def next_survey_for(user)
@@ -23,7 +23,7 @@ module Decidim
             .joins(:survey)
             .where("decidim_components.weight > ?", survey.weight)
             .sort_by { |s| s.survey.weight }
-            &.find { |s| !s.survey.answered_by?(user.id) }
+            .find { |s| !s.survey.answered_by?(user.id) }
       end
     end
   end


### PR DESCRIPTION
Fix; previous_survey_for and next_survey_for methods take now the survey not answered by the current user with the closed weight in the same survey_section