### PR TITLE
Flash alert on mandatory survey

### DIFF
--- a/app/lib/decidim/overrides/surveys/surveys_controller.rb
+++ b/app/lib/decidim/overrides/surveys/surveys_controller.rb
@@ -5,7 +5,7 @@ module Decidim
     module Surveys
       module SurveysController
         def show
-          flash[:alert] = t('decidim.surveys.surveys.show.flash.alert') unless current_component.mandatory_survey_answered_by?(current_user)
+          flash[:alert] = t("decidim.surveys.surveys.show.flash.alert") unless current_component.mandatory_survey_answered_by?(current_user)
           return head 403 unless current_component.weight == 1 || current_component.mandatory_survey_answered_by?(current_user)
           return super unless visitor_already_answered? && sat_set
 

--- a/app/lib/decidim/overrides/surveys/surveys_controller.rb
+++ b/app/lib/decidim/overrides/surveys/surveys_controller.rb
@@ -5,6 +5,7 @@ module Decidim
     module Surveys
       module SurveysController
         def show
+          flash[:alert] = t('decidim.surveys.surveys.show.flash.alert') if !current_component.mandatory_survey_answered_by?(current_user)
           return head 403 unless current_component.weight == 1 || current_component.mandatory_survey_answered_by?(current_user)
           return super unless visitor_already_answered? && sat_set
 

--- a/app/lib/decidim/overrides/surveys/surveys_controller.rb
+++ b/app/lib/decidim/overrides/surveys/surveys_controller.rb
@@ -5,7 +5,7 @@ module Decidim
     module Surveys
       module SurveysController
         def show
-          flash[:alert] = t('decidim.surveys.surveys.show.flash.alert') if !current_component.mandatory_survey_answered_by?(current_user)
+          flash[:alert] = t('decidim.surveys.surveys.show.flash.alert') unless current_component.mandatory_survey_answered_by?(current_user)
           return head 403 unless current_component.weight == 1 || current_component.mandatory_survey_answered_by?(current_user)
           return super unless visitor_already_answered? && sat_set
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -61,6 +61,9 @@ en:
       conferences: Calendars
     surveys:
       surveys:
+        show:
+          flash:
+            alert: "This Topic is mandatory and has to be filled in first"
         feedback:
           back: Back
           card:


### PR DESCRIPTION
Flash alert added into show controller in order to inform that the mandatory survey is not filled in yet.
![image](https://user-images.githubusercontent.com/71900287/229090251-46cf55e1-a88d-4f6b-a480-3d49377aa0ce.png)
